### PR TITLE
Remove support for using `request.referer` as redirect URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ class ApplicationController < ActionController::Base
 
   private
     def authenticate
-      redirect_to new_session_url unless Current.user
+      # Pass `redirect_url:` to pass the URL we're currently on.
+      redirect_to new_session_url(redirect_url: request.url) unless Current.user
     end
 end
 
 class SessionsController < ApplicationController
   # Stash a redirect at the start of the session authentication flow,
-  # from either params[:redirect_url] or request.referer in that order.
+  # from `params[:redirect_url]` automatically.
   stash_redirect_for :sign_in, on: :new
 
   def new

--- a/test/action_controller/stashed_redirects_test.rb
+++ b/test/action_controller/stashed_redirects_test.rb
@@ -56,7 +56,7 @@ class ActionController::StashedRedirects::HooksTest < ActiveSupport::TestCase
   end
 
   test "passing the wrong URL raises" do
-    assert_raises(ArgumentError) { stash_redirect_for :sign_in, url: nil }
+    assert_raises(ArgumentError) { stash_redirect_for :sign_in, url: -> { nil } }
     assert_raises(ArgumentError) { stash_redirect_for :sign_in, url: "http://google.com" }
   end
 

--- a/test/action_controller/stashed_redirects_test.rb
+++ b/test/action_controller/stashed_redirects_test.rb
@@ -36,27 +36,13 @@ end
 
 class ActionController::StashedRedirects::HooksTest < ActiveSupport::TestCase
   module Context
-    def session
-      @session ||= {}
-    end
-
-    def params
-      @params ||= { redirect_url: "/users/param" }
-    end
-
-    def request
-      @request ||= Struct.new(:host, :referer) { def get? = true }.new "http://example.com", "/users/referer"
-    end
+    def request = @request ||= Struct.new(:host).new("http://example.com")
+    def session = @session ||= {}
+    def params  = { redirect_url: "/users/param" }
 
     def redirect_to(url, *) = url
-
-    def url_from(url)
-      if url.present?
-        url if URI(url.to_s).host.then { _1.nil? || _1 == request.host }
-      end
-    end
+    def url_from(url) = URI(url.to_s).host.then { _1.nil? || _1 == request.host } && url
   end
-
   include Context, ActionController::StashedRedirects
 
   test "from redirect_url" do

--- a/test/action_controller/stashed_redirects_test.rb
+++ b/test/action_controller/stashed_redirects_test.rb
@@ -15,15 +15,7 @@ class ActionController::StashedRedirectsTest < ActionDispatch::IntegrationTest
     assert_redirected_to users_url
   end
 
-  test "stash and recall redirect from the referer" do
-    get new_session_url, headers: { HTTP_REFERER: users_url }
-    assert_response :no_content
-
-    post sessions_url
-    assert_redirected_to users_url
-  end
-
-  test "passing from: block accesses instance context" do
+  test "passing url: block accesses instance context" do
     delete session_url(id: 1)
     assert_redirected_to users_url
   end
@@ -67,29 +59,19 @@ class ActionController::StashedRedirects::HooksTest < ActiveSupport::TestCase
 
   include Context, ActionController::StashedRedirects
 
-  test "param takes precedence over referer" do
+  test "from redirect_url" do
     stash_redirect_for :sign_in
     assert_equal "/users/param", redirect_from_stashed(:sign_in)
   end
 
-  test "from param" do
-    stash_redirect_for :sign_in, from: :param
-    assert_equal "/users/param", redirect_from_stashed(:sign_in)
-  end
-
-  test "from referer" do
-    stash_redirect_for :sign_in, from: :referer
-    assert_equal "/users/referer", redirect_from_stashed(:sign_in)
-  end
-
   test "explicit url override" do
-    stash_redirect_for :sign_in, from: "/users/explicit"
+    stash_redirect_for :sign_in, url: "/users/explicit"
     assert_equal "/users/explicit", redirect_from_stashed(:sign_in)
   end
 
   test "passing the wrong URL raises" do
-    assert_raises(ArgumentError) { stash_redirect_for :sign_in, from: nil }
-    assert_raises(ArgumentError) { stash_redirect_for :sign_in, from: "http://google.com" }
+    assert_raises(ArgumentError) { stash_redirect_for :sign_in, url: nil }
+    assert_raises(ArgumentError) { stash_redirect_for :sign_in, url: "http://google.com" }
   end
 
   test "no stashed redirect raises" do

--- a/test/boot/action_controller.rb
+++ b/test/boot/action_controller.rb
@@ -4,7 +4,7 @@ end
 
 class SessionsController < ApplicationController
   stash_redirect_for :sign_in,  on: :new
-  stash_redirect_for :sign_out, on: :destroy, from: -> { users_url }
+  stash_redirect_for :sign_out, on: :destroy, url: :users_url
 
   def new
     head :no_content


### PR DESCRIPTION
Redirects preserve the original `HTTP_REFERER` which isn't what we want.

You must either use `params[:redirect_url]` or pass an explicit URL with something like this:

```ruby
stash_redirect_for :sign_in, on: :new, url: :root_url
stash_redirect_for :sign_in, on: :new, url: -> { request.url }
```

@dixpac have you been using the `referer` feature?