### PR TITLE
Bump to minimum 3.0.0

### DIFF
--- a/action_controller-stashed_redirects.gemspec
+++ b/action_controller-stashed_redirects.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary  = "Embed a controller flow within another by stashing the final redirect upfront and performing it after completing."
   spec.homepage = "https://github.com/kaspth/action_controller-stashed_redirects"
   spec.license  = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
I've been using 3.0 syntax already and it's EOL'ed for almost a year now.