### PR TITLE
Add `redirect_forward_or_to`.

### DIFF
--- a/lib/action_controller/stashed_redirects.rb
+++ b/lib/action_controller/stashed_redirects.rb
@@ -83,12 +83,18 @@ module ActionController::StashedRedirects
       end
     end
 
+    # Syntactic sugar for redirecting to `redirect_url` with a fallback.
+    #
+    #   redirect_forward_or_to root_url # => redirect_to redirect_url || root_url
+    def redirect_forward_or_to(fallback_url)
+      redirect_to redirect_url || fallback_url
+    end
+
     # Looks up a redirect URL from `params[:redirect_url]` using
-    # `url_from` as the protection mechanism to ensure it's a valid internal redirect.
+    # Rails' `url_from` as the protection mechanism to ensure it's a valid internal redirect.
+    # See the `url_from` docs: https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-url_from
     #
-    # Can be passed to `redirect_to` with a fallback:
-    #
-    #   redirect_to redirect_url || users_url
+    # You probably want to use `redirect_forward_or_to`.
     def redirect_url = url_from(params[:redirect_url])
 
     DEFAULT_URL = Object.new

--- a/test/action_controller/stashed_redirects_test.rb
+++ b/test/action_controller/stashed_redirects_test.rb
@@ -32,6 +32,14 @@ class ActionController::StashedRedirectsTest < ActionDispatch::IntegrationTest
     get new_session_url
     assert_response :internal_server_error
   end
+
+  test "redirect_forward_or_to" do
+    get forward_sessions_redirects_url, params: { redirect_url: users_url }
+    assert_redirected_to users_url
+
+    get forward_sessions_redirects_url
+    assert_redirected_to root_url
+  end
 end
 
 class ActionController::StashedRedirects::HooksTest < ActiveSupport::TestCase

--- a/test/boot/action_controller.rb
+++ b/test/boot/action_controller.rb
@@ -24,5 +24,9 @@ module Sessions
     def create
       redirect_from_stashed :sign_in
     end
+
+    def forward
+      redirect_forward_or_to root_url
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,10 +27,14 @@ Rails.application.initialize!
 Rails.application.routes.draw do
   resources :sessions
   namespace :sessions do
-    resources :redirects
+    resources :redirects do
+      get :forward, on: :collection
+    end
   end
 
   resources :users
+
+  root to: "sessions#new"
 end
 
 require_relative "boot/action_controller"


### PR DESCRIPTION
I'm keen to explore more controller language that focuses on advance/forward or regress, in other words movements.
E.g. a successful action moves you forward to another action, while an unsuccessful action makes you recede.

I don't have more on that right now, but I explored something like it here: https://github.com/excid3/rails/pull/2#issuecomment-1760041620

So `redirect_forward_or_to` starts establishing that, but it's really just syntactic sugar around `redirect_to redirect_url || fallback_url`.